### PR TITLE
fix(panic):use nil map in server callWithRecover

### DIFF
--- a/app/server/server_reflect.go
+++ b/app/server/server_reflect.go
@@ -128,6 +128,9 @@ func callWithRecover(fun reflect.Method, inVal []reflect.Value) (m map[string]in
 		if re := recover(); re != nil {
 			hasError = true
 			log.Printf("[RECOVER] panic in remote func call: %s\n", re)
+			if m == nil {
+				m = make(map[string]interface{})
+			}
 			m["err"] = errors.New(fmt.Sprintf("server func call recover: %s", re))
 		}
 	}()


### PR DESCRIPTION
修复了服务端在接受rpc调用后修复panic时，由于map没有初始化造成的二次panic问题